### PR TITLE
fix: exit at-driver with error if run as admin

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const {exec} = require('child_process');
+const {promisify} = require('util');
+
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
 
@@ -7,6 +10,16 @@ const createCommandServer = require('./create-command-server');
 const createVoiceServer = require('./create-voice-server');
 const NAMED_PIPE = '\\\\?\\pipe\\my_pipe';
 const DEFAULT_PORT = 4382;
+
+
+const isAdmin = async () => {
+  try {
+    await promisify(exec)('net session');
+    return true;
+  } catch ({}) {
+    return false;
+  }
+};
 
 /**
  * Print logging information to the process's standard error stream, annotated
@@ -34,6 +47,15 @@ module.exports = async (process) => {
       requiresArg: true,
     })
     .parse();
+
+  if (await isAdmin()) {
+    // Running at-driver with admin privilege creates the named pipe so that admin privilege is
+    // required to connect to the pipe. An application, such as a screen reader, using the
+    // automation voice will try to connect to the pipe and likely fail as it will be unlikely to
+    // have been run with admin privilege.
+    log(`executed with admin privilege. run at-driver without admin privilege.`);
+    process.exit(1);
+  }
 
   const [commandServer, voiceServer] = await Promise.all([
     createCommandServer(argv.port),


### PR DESCRIPTION
When at-driver is run with admin privilege, clients of the named pipe will need the same privilege. It is easy to overlook this when starting at-driver and then using for example a screen reader that is not run with admin privilege. When the automation voice is loaded by said screen reader if it doesn't have equal or better privilege it will not be able to connect to the named pipe. At this time the voice cannot notify the user of this issue and appears to silently fail.