### PR TITLE
fix: run vocalizer before adding voice to set default voice

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -183,7 +183,7 @@ const operations = {
 
     // A default text to speech voice is chosen when first used. Vocalize some
     // text to make the system choose and save a default from the currently
-    // installed voices. Additionally test that text to speech succeeds.
+    // installed voices. Additionally test that text to speech works locally.
     await vocalize('Installing automation voice');
 
     await registerDll(DLL_PATH);

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -44,6 +44,7 @@ const VOICE = Object.freeze({
 const DLL_PATH = path.join(__dirname, '..', 'Release', 'AutomationTtsEngine.dll');
 const VOCALIZER_LOCAL_PATH = path.join(__dirname, '..', 'Release', 'Vocalizer.exe');
 const VOCALIZER_GLOBAL_DIRECTORY = 'C:\\Program Files\\Bocoup Automation Voice';
+const VOCALIZER_GLOBAL_PATH = path.join(VOCALIZER_GLOBAL_DIRECTORY, 'Vocalizer.exe');
 const BASE_REGISTRY_PATH = 'HKLM\\SOFTWARE\\Microsoft\\Speech\\Voices\\Tokens';
 
 // > # regsvr32
@@ -71,6 +72,19 @@ const copyFile = async (sourceFile, destinationDir) => {
     readStream.on('end', resolve);
     readStream.on('error', reject);
     writeStream.on('error', reject);
+  });
+};
+
+/**
+ * Speak `text` with the Vocalizer.exe program.
+ *
+ * @param {string} text
+ */
+const vocalize = async (text) => {
+  await exec(`${JSON.stringify(VOCALIZER_GLOBAL_PATH)}`, {
+    env: {
+      WORDS: text,
+    },
   });
 };
 
@@ -166,6 +180,8 @@ const deregisterVoice = async ({id, arch}) => {
 const operations = {
   async install() {
     await copyFile(VOCALIZER_LOCAL_PATH, VOCALIZER_GLOBAL_DIRECTORY);
+
+    await vocalize('Installing automation voice');
 
     await registerDll(DLL_PATH);
 

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -81,7 +81,7 @@ const copyFile = async (sourceFile, destinationDir) => {
  * @param {string} text
  */
 const vocalize = async (text) => {
-  await exec(`${JSON.stringify(VOCALIZER_GLOBAL_PATH)}`, {
+  await exec(JSON.stringify(VOCALIZER_GLOBAL_PATH), {
     env: {
       WORDS: text,
     },
@@ -181,6 +181,9 @@ const operations = {
   async install() {
     await copyFile(VOCALIZER_LOCAL_PATH, VOCALIZER_GLOBAL_DIRECTORY);
 
+    // A default text to speech voice is chosen when first used. Vocalize some
+    // text to make the system choose and save a default from the currently
+    // installed voices. Additionally test that text to speech succeeds.
     await vocalize('Installing automation voice');
 
     await registerDll(DLL_PATH);


### PR DESCRIPTION
We realized using sapi to speak will make a default from currently installed voices be chosen. If the automation voice is installed before, that default will become the voice. This is not intended. To help users of the automation voice avoid this situation we can make a default be chosen before installing the automated voice by using Vocalizer to speak.

