### PR TITLE
chore: add ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,55 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: CI
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        node:
+          - 12
+          - 14
+          - 16
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+        with:
+          vs-version: 14.2
+      - name: Audio device
+        run: Get-CimInstance Win32_SoundDevice | fl *
+      - name: Install Scream
+        shell: powershell
+        run: |
+          Start-Service audio*
+          Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/3.6/Scream3.6.zip -OutFile C:\Scream3.6.zip
+          Extract-7Zip -Path C:\Scream3.6.zip -DestinationPath C:\Scream
+          $cert = (Get-AuthenticodeSignature C:\Scream\Install\driver\Scream.sys).SignerCertificate
+          $store = [System.Security.Cryptography.X509Certificates.X509Store]::new("TrustedPublisher", "LocalMachine")
+          $store.Open("ReadWrite")
+          $store.Add($cert)
+          $store.Close()
+          cd C:\Scream\Install\driver
+          C:\Scream\Install\helpers\devcon install Scream.inf *Scream
+      - name: Audio device
+        run: Get-CimInstance Win32_SoundDevice | fl *
+      - name: Build ttseng
+        run: msbuild src\automationttsengine\AutomationTtsEngine.vcxproj -t:build -verbosity:diag -property:Configuration=Release '-property:SolutionDir=$(MSBuildProjectDirectory)\..\..\'
+      - name: Build Vocalizer
+        run: msbuild src\Vocalizer\Vocalizer.vcxproj -t:build -verbosity:diag -property:Configuration=Release '-property:SolutionDir=$(MSBuildProjectDirectory)\..\..\'
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      - run: npm test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,4 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+# This workflow will build windows projects in visual studio and run tests using node.
 
 name: CI
 
@@ -27,7 +26,8 @@ jobs:
         uses: microsoft/setup-msbuild@v1.1
         with:
           vs-version: 14.2
-      - name: Audio device
+      - # https://github.com/actions/virtual-environments/issues/2528#issuecomment-766883233
+        name: Audio device
         run: Get-CimInstance Win32_SoundDevice | fl *
       - name: Install Scream
         shell: powershell

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -9,7 +9,7 @@
 const child_process = require('child_process');
 const {promisify} = require('util');
 const path = require('path');
-const fs = require('fs/promises');
+const {promises: fs} = require('fs');
 const {createReadStream, createWriteStream} = require('fs');
 
 const sudo_prompt = require('sudo-prompt');

--- a/src/automationttsengine/AutomationTtsEngine.vcxproj
+++ b/src/automationttsengine/AutomationTtsEngine.vcxproj
@@ -167,10 +167,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
-    <PostBuildEvent>
-      <Message>Performing Registration</Message>
-      <Command>regsvr32 /s /c "$(TargetPath)"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Midl>


### PR DESCRIPTION
Add CI github workflow.

This workflow does the following:
- Install a virtual audio device
- Build automationttsengine and vocalizer visual studio projects
- npm install with `npm ci`
- `npm test`