### PR TITLE
Centralize installation logic & reduce admin reqs

### DIFF
--- a/src/automationttsengine/AutomationTtsEngine.vcxproj
+++ b/src/automationttsengine/AutomationTtsEngine.vcxproj
@@ -167,10 +167,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
-    <PostBuildEvent>
-      <Message>Performing Registration</Message>
-      <Command>regsvr32 /s /c "$(TargetPath)"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Midl>
@@ -196,10 +192,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
-    <PostBuildEvent>
-      <Message>Performing Registration</Message>
-      <Command>regsvr32 /s /c "$(TargetPath)"</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AutomationTtsEngine.cpp" />

--- a/src/makevoice/MakeVoice.cpp
+++ b/src/makevoice/MakeVoice.cpp
@@ -49,11 +49,59 @@ std::string getSiblingFilePath(const std::string& fileName)
     return path.substr(0, 1 + path.find_last_of('\\')) + fileName;
 }
 
+HRESULT registerDll(const std::string& fileName)
+{
+    USES_CONVERSION;
+
+    STARTUPINFO startup_info;
+    PROCESS_INFORMATION process_info;
+    ZeroMemory(&startup_info, sizeof(startup_info));
+    startup_info.cb = sizeof(startup_info);
+    ZeroMemory(&process_info, sizeof(process_info));
+    std::string command = std::string("regsvr32 /s /c \"") + getSiblingFilePath(fileName) + "\"";
+    DWORD dwFlags = CREATE_NO_WINDOW;
+
+    bool result = CreateProcessW(
+        NULL,
+        A2W(command.c_str()),
+        NULL,
+        NULL,
+        false,
+        dwFlags,
+        NULL,
+        NULL,
+        &startup_info,
+        &process_info
+    );
+
+    if (!result)
+    {
+        return E_FAIL;
+    }
+
+    WaitForSingleObject(process_info.hProcess, INFINITE);
+
+    DWORD exitCode;
+
+    if (!GetExitCodeProcess(process_info.hProcess, &exitCode))
+    {
+        return E_FAIL;
+    }
+
+    CloseHandle(process_info.hProcess);
+    CloseHandle(process_info.hThread);
+
+    return exitCode == 0 ? S_OK : E_FAIL;
+}
+
 int wmain(int argc, __in_ecount(argc) WCHAR* argv[])
 {
-    HRESULT hr = S_OK;
+    HRESULT hr = ::CoInitialize( NULL );
 
-    ::CoInitialize( NULL );
+    if (SUCCEEDED(hr))
+    {
+        hr = registerDll("AutomationTtsEngine.dll");
+    }
 
     // Programatically create a token for the new voice and set its attributes.
     if (SUCCEEDED(hr))

--- a/src/makevoice/MakeVoice.vcxproj
+++ b/src/makevoice/MakeVoice.vcxproj
@@ -151,6 +151,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX86</TargetMachine>
+      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
     </Link>
     <PostBuildEvent>
       <Message>Build and register voice file</Message>


### PR DESCRIPTION
Prior to this patch, the project's C++ code could only be built if
Microsoft Visual Studio was run with the privileges of a system
administrator.

Encapsulate installation steps in the MakeVoice.exe binary, and extend
that binary to require administrative privileges (allowing the code to
be built without them).

This change also supports forthcoming work to eliminate duplicated
installation logic between the project's Node.js code and C++ code.